### PR TITLE
Check for sourceUrl on fhirRecord

### DIFF
--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -130,7 +130,7 @@ public class EhrPlugin: CAPPlugin {
                 "endDate": clinicalSample.endDate.description,
                 "uuid": clinicalSample.uuid.uuidString,
                 "metadata": clinicalSample.metadata ?? "",
-                "sourceURL": (clinicalSample.fhirResource?.sourceURL!.absoluteString)!,
+                "sourceURL": (clinicalSample.fhirResource?.sourceURL?.absoluteString) ?? "",
                 "displayName": clinicalSample.displayName,
                 "fhirResource": self.toJson(data: clinicalSample.fhirResource!.data)
             ]


### PR DESCRIPTION
I faced an error when getting medical records from LabCorp. They do not include the soruceURl. This is to return and empty string if the url is undefined